### PR TITLE
Import of fesom2depth in regridding.py. 

### DIFF
--- a/pyfesom/regriding.py
+++ b/pyfesom/regriding.py
@@ -9,6 +9,7 @@
 from scipy.spatial import cKDTree
 import numpy as np
 from collections import namedtuple
+from .load_mesh_data import fesom2depth
 
 def lon_lat_to_cartesian(lon, lat, R = 6371000):
     """


### PR DESCRIPTION
Otherwise I get a 'NameError: global name 'fesom2depth' is not defined' when calling fesom2clim in my script. This can possibly be solved differently, you may want to have a look.