### PR TITLE
Avoid temporary (large) list when reading aux3d.out

### DIFF
--- a/pyfesom/fesom2gdal.py
+++ b/pyfesom/fesom2gdal.py
@@ -62,7 +62,7 @@ def fesom2gdal(mesh,outputname,gdaldriver='GPKG'):
     surftype=ogr.wkbPolygon
 
 
-    tinlayer = data_source.CreateLayer("tin", srs, ogr.wkbTriangle)
+    tinlayer = data_source.CreateLayer("tin", srs, surftype)
 
     # Add the fields we're interested in (nodeid's of 
     field_nodeid = ogr.FieldDefn("nodeid", ogr.OFTIntegerList)

--- a/pyfesom/load_mesh_data.py
+++ b/pyfesom/load_mesh_data.py
@@ -289,8 +289,8 @@ class fesom_mesh(object):
 
         with open(self.aux3dfile) as f:
             self.nlev=int(next(f))
-            self.n32=np.array([next(f) for x in \
-                            range(self.n2d*self.nlev)]).astype(int).reshape(self.n2d, self.nlev)   
+            self.n32=np.fromiter(f,dtype=np.int32,count=self.n2d*self.nlev).reshape(self.n2d,self.nlev)
+        
         self.topo=np.zeros(shape=(self.n2d))
         for prof in self.n32:           
             ind_nan = prof[prof>0]


### PR DESCRIPTION
Hi Nikolay,
here are two minor changes which you may want to merge.

(1) I had a MemoryError on a relatively light Virtual Machine when using fesom_mesh on a dense grid. I could fix (i.e. reduce memory footprint) it by using numpy.fromiter to fill an ndarray directly from the "aux3d.out" file, and avoiding the allocation of an intermediate list which was input to numpy.array.

(2) A small bug I found in fesom2gdal where I forgot to refer to the variable surftype and wrongly used ogr.wkbTriangle. This is valid code, but in Qgis, geometries of the type ogr.wkbTriangle won't be visible, so I use a plain polygon now to represent the triangular surface elements.

all the best,
Roelof

